### PR TITLE
Debug 502 errors

### DIFF
--- a/pm/management/commands/import_total_hours.py
+++ b/pm/management/commands/import_total_hours.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
 
 		# Delete any existig recent time entries from RecentWork table
 		#existing_recent_time_entries = RecentWork.objects.all().delete
-		RecentWork.objects.all().delete
+		RecentWork.objects.all().delete()
 
 		# Add project_ids to RecentWork table from the Redmine query
 		for entry in recent_project_ids:

--- a/pm/management/commands/import_total_hours.py
+++ b/pm/management/commands/import_total_hours.py
@@ -28,7 +28,8 @@ class Command(BaseCommand):
 		recent_project_ids = list(recent_project_hours.keys())
 
 		# Delete any existig recent time entries from RecentWork table
-		existing_recent_time_entries = RecentWork.objects.all().delete
+		#existing_recent_time_entries = RecentWork.objects.all().delete
+		RecentWork.objects.all().delete
 
 		# Add project_ids to RecentWork table from the Redmine query
 		for entry in recent_project_ids:

--- a/pm/static/pm/css/style.css
+++ b/pm/static/pm/css/style.css
@@ -28,6 +28,7 @@ h2 {margin: 0 0 25px 0;}
 .label-non-billable { background-color: #7F66FF;}
 
 #search_input {margin-top:-55px; display:inline; position:absolute; right:15px; width: 200px;}
+#search_input[type=search]::-webkit-search-cancel-button {-webkit-appearance: searchfield-cancel-button; }
 
 th { height: 55px; width: 25px; }
 td { height: 50px; width: 25px; }

--- a/pm/templates/pm/index.html
+++ b/pm/templates/pm/index.html
@@ -9,7 +9,7 @@
 					<h1>Projects</h1>
 					<p>Work we've spent time on in the last couple of weeks.</p>
 					<div class="form-group">
-						<input id="search_input" type="text" placeholder="filter projects" class="form-control">
+						<input id="search_input" type="search" placeholder="filter projects" class="form-control">
 					</div>
 				</div>
 			</div>

--- a/pm/views.py
+++ b/pm/views.py
@@ -29,7 +29,7 @@ import requests
 def project_list(request):
 
 	# Configure Redmine reqest
-	redmine = Redmine(settings.REDMINE_URL, version=settings.REDMINE_VER, key=settings.REDMINE_KEY)
+	# redmine = Redmine(settings.REDMINE_URL, version=settings.REDMINE_VER, key=settings.REDMINE_KEY)
 	
 	# Get time entries from the last X days from Redmine
 	# date_N_days_ago = (datetime.now() - timedelta(days=14)).strftime('%Y-%m-%d')
@@ -138,8 +138,8 @@ def project_list(request):
 			# if all_projects_details[entry]["category"] == "Non-billable":
 			# 	all_projects_details[entry]["category_type"] = '<span class="label label-primary">Non-billable</span>'
 
-		elif entry not in other_pm_project_ids:
-			all_projects_details[entry] = {"project_id": entry, "deadline": ''}
+		# elif entry not in other_pm_project_ids:
+		# 	all_projects_details[entry] = {"project_id": entry, "deadline": ''}
 
 	sorted_all_projects_details = sorted(all_projects_details.items(), key=lambda v: (v[1]['deadline'] == '', v[1]['deadline'] is None, v[1]['deadline']))
 

--- a/pm/views.py
+++ b/pm/views.py
@@ -51,7 +51,7 @@ def project_list(request):
 		recent_project_ids.append(entry.redmine_project_id)
 
 	# Get a list of all defined projects from the Projectmatica db that:
-	#  - are categorized as Billable or Non-billable
+	#  - are categorized as Billable or Non-billable (don't get list of non-billable projects, yet!)
 	#  - don't have a completed_on date
 	# defined_projects = Project.objects.filter(category__category_name__in = ['Billable', 'Non-billable']).exclude(completed_on__isnull=False)
 	defined_projects = Project.objects.filter(category__category_name__in = ['Billable']).exclude(completed_on__isnull=False)

--- a/pm/views.py
+++ b/pm/views.py
@@ -138,7 +138,8 @@ def project_list(request):
 			# if all_projects_details[entry]["category"] == "Non-billable":
 			# 	all_projects_details[entry]["category_type"] = '<span class="label label-primary">Non-billable</span>'
 
-		# elif entry not in other_pm_project_ids:
+		# Add list of Uncategorized projects
+		elif entry not in other_pm_project_ids:
 			all_projects_details[entry] = {"project_id": entry, "deadline": ''}
 
 	sorted_all_projects_details = sorted(all_projects_details.items(), key=lambda v: (v[1]['deadline'] == '', v[1]['deadline'] is None, v[1]['deadline']))

--- a/pm/views.py
+++ b/pm/views.py
@@ -139,31 +139,31 @@ def project_list(request):
 			# 	all_projects_details[entry]["category_type"] = '<span class="label label-primary">Non-billable</span>'
 
 		# elif entry not in other_pm_project_ids:
-		# 	all_projects_details[entry] = {"project_id": entry, "deadline": ''}
+			all_projects_details[entry] = {"project_id": entry, "deadline": ''}
 
 	sorted_all_projects_details = sorted(all_projects_details.items(), key=lambda v: (v[1]['deadline'] == '', v[1]['deadline'] is None, v[1]['deadline']))
 
 
 	# Build a list of inactivate projects
-	# all_billable_projects = Project.objects.filter(category__category_name__in = ['Billable']).exclude(completed_on__isnull=False)
-	# displayed_inactive_projects = []
-	# inactive_project_details = dict()
-	# for entry in all_billable_projects:
-	# 	if entry.redmine_project_id not in recent_project_ids:
-	# 		inactive_project_details = {
-	# 			"redmine_project_id": entry.redmine_project_id,
-	# 			"client": entry.client_name,
-	# 			"deadline": entry.deadline,
-	# 			"project_desc": entry.project_desc,
-	# 			"identifier": entry.redmine_project_url
-	# 		}
-	# 		displayed_inactive_projects.append(inactive_project_details)
+	all_billable_projects = Project.objects.filter(category__category_name__in = ['Billable']).exclude(completed_on__isnull=False)
+	displayed_inactive_projects = []
+	inactive_project_details = dict()
+	for entry in all_billable_projects:
+		if entry.redmine_project_id not in recent_project_ids:
+			inactive_project_details = {
+				"redmine_project_id": entry.redmine_project_id,
+				"client": entry.client_name,
+				"deadline": entry.deadline,
+				"project_desc": entry.project_desc,
+				"identifier": entry.redmine_project_url
+			}
+			displayed_inactive_projects.append(inactive_project_details)
 
 
 	context = {
 		"show_menu" : True,
-		"sorted_all_projects_details": sorted_all_projects_details
-		# "displayed_inactive_projects": displayed_inactive_projects
+		"sorted_all_projects_details": sorted_all_projects_details,
+		"displayed_inactive_projects": displayed_inactive_projects
 	}
 
 	return render(request, 'pm/index.html', context)

--- a/pm/views.py
+++ b/pm/views.py
@@ -145,25 +145,25 @@ def project_list(request):
 
 
 	# Build a list of inactivate projects
-	all_billable_projects = Project.objects.filter(category__category_name__in = ['Billable']).exclude(completed_on__isnull=False)
-	displayed_inactive_projects = []
-	inactive_project_details = dict()
-	for entry in all_billable_projects:
-		if entry.redmine_project_id not in recent_project_ids:
-			inactive_project_details = {
-				"redmine_project_id": entry.redmine_project_id,
-				"client": entry.client_name,
-				"deadline": entry.deadline,
-				"project_desc": entry.project_desc,
-				"identifier": entry.redmine_project_url
-			}
-			displayed_inactive_projects.append(inactive_project_details)
+	# all_billable_projects = Project.objects.filter(category__category_name__in = ['Billable']).exclude(completed_on__isnull=False)
+	# displayed_inactive_projects = []
+	# inactive_project_details = dict()
+	# for entry in all_billable_projects:
+	# 	if entry.redmine_project_id not in recent_project_ids:
+	# 		inactive_project_details = {
+	# 			"redmine_project_id": entry.redmine_project_id,
+	# 			"client": entry.client_name,
+	# 			"deadline": entry.deadline,
+	# 			"project_desc": entry.project_desc,
+	# 			"identifier": entry.redmine_project_url
+	# 		}
+	# 		displayed_inactive_projects.append(inactive_project_details)
 
 
 	context = {
 		"show_menu" : True,
-		"sorted_all_projects_details": sorted_all_projects_details,
-		"displayed_inactive_projects": displayed_inactive_projects
+		"sorted_all_projects_details": sorted_all_projects_details
+		# "displayed_inactive_projects": displayed_inactive_projects
 	}
 
 	return render(request, 'pm/index.html', context)

--- a/pm/views.py
+++ b/pm/views.py
@@ -53,7 +53,8 @@ def project_list(request):
 	# Get a list of all defined projects from the Projectmatica db that:
 	#  - are categorized as Billable or Non-billable
 	#  - don't have a completed_on date
-	defined_projects = Project.objects.filter(category__category_name__in = ['Billable', 'Non-billable']).exclude(completed_on__isnull=False)
+	# defined_projects = Project.objects.filter(category__category_name__in = ['Billable', 'Non-billable']).exclude(completed_on__isnull=False)
+	defined_projects = Project.objects.filter(category__category_name__in = ['Billable']).exclude(completed_on__isnull=False)
 
 	defined_projects_details = dict()
 	project_details = dict()
@@ -134,8 +135,8 @@ def project_list(request):
 				all_projects_details[entry]["tm_status"] = ''
 
 			# Set Non-billable indicator
-			if all_projects_details[entry]["category"] == "Non-billable":
-				all_projects_details[entry]["category_type"] = '<span class="label label-primary">Non-billable</span>'
+			# if all_projects_details[entry]["category"] == "Non-billable":
+			# 	all_projects_details[entry]["category_type"] = '<span class="label label-primary">Non-billable</span>'
 
 		elif entry not in other_pm_project_ids:
 			all_projects_details[entry] = {"project_id": entry, "deadline": ''}


### PR DESCRIPTION
Fixes #26 

502 errors were happening because 300,000+ rows had been added to the RecentWork table and weren't being flushed out periodically.

Changed management command to delete table contents periodically, as was originally intended. Tested in prod; works.

Added back the Inactive and Uncategorized project lists to the Dashboard (for Admin users).