### PR TITLE
Refactor how settings are organized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ myvenv
 db.sqlite3
 /static
 .DS_Store
-settings.py
+settings0.py
 /pm/management/commands/time_import_log
 /projectmatica-env
 db.sqlite3 copy
+/asites/settings/.env

--- a/asites/settings/base.py
+++ b/asites/settings/base.py
@@ -3,6 +3,7 @@ Common settings and globals (local and production).
 Environment vars are defined in a .env file stored in the settings directory.
 django-environ is a dependency. install instructions: http://django-environ.readthedocs.io/en/latest/index.html
 see env variable config instructions at http://django-environ.readthedocs.io/en/latest/
+.env variable assignment syntax --> FOO='BAR' (no spaces allowed around the '=')
 """
 
 import os

--- a/asites/settings/base.py
+++ b/asites/settings/base.py
@@ -1,6 +1,7 @@
 """
 Common settings and globals (local and production).
 Environment vars are defined in a .env file stored in the settings directory.
+django-environ is a dependency. install instructions: http://django-environ.readthedocs.io/en/latest/index.html
 see env variable config instructions at http://django-environ.readthedocs.io/en/latest/
 """
 

--- a/asites/settings/base.py
+++ b/asites/settings/base.py
@@ -31,7 +31,6 @@ path.append(DJANGO_ROOT)
 
 
 ########## SITE CONFIGURATION
-# SECRET_KEY = '4m-z^&eglub_uix0t@ayy2h7fld#h6ay)q^*m&hl#l(o!@m0(e'
 SECRET_KEY = env('DJANGO_SECRET_KEY')
 DEBUG = env('DEBUG') # False if not in os.environ
 # ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]']

--- a/asites/settings/base.py
+++ b/asites/settings/base.py
@@ -1,0 +1,122 @@
+"""
+Common settings and globals (local and production).
+Environment vars are defined in a .env file stored in the settings directory.
+see env variable config instructions at http://django-environ.readthedocs.io/en/latest/
+"""
+
+import os
+from os import environ
+from os.path import abspath, basename, dirname, join, normpath
+from sys import path
+import environ
+env = environ.Env(DEBUG=(bool, False),) # set default values and casting
+environ.Env.read_env() # reading .env file
+
+
+########## PATH CONFIGURATION
+# Absolute filesystem path to the Django project directory:
+DJANGO_ROOT = dirname(dirname(dirname(abspath(__file__))))
+
+# Absolute filesystem path to the top-level project folder:
+SITE_ROOT = dirname(DJANGO_ROOT)
+
+# Site name:
+SITE_NAME = basename(DJANGO_ROOT)
+
+# Add our project to our pythonpath, this way we don't need to type our project
+# name in our dotted import paths:
+path.append(DJANGO_ROOT)
+########## END PATH CONFIGURATION
+
+
+########## SITE CONFIGURATION
+# SECRET_KEY = '4m-z^&eglub_uix0t@ayy2h7fld#h6ay)q^*m&hl#l(o!@m0(e'
+SECRET_KEY = env('DJANGO_SECRET_KEY')
+DEBUG = env('DEBUG') # False if not in os.environ
+# ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]']
+ALLOWED_HOSTS = []
+########## END SITE CONFIGURATION
+
+
+########## APPLICATION CONFIGURATION
+INSTALLED_APPS = [
+    'pm.apps.PmConfig',
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    # 'csvimport.app.CSVImportConf',
+    # 'mathfilters',
+]
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+ROOT_URLCONF = 'asites.urls'
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(DJANGO_ROOT, 'templates')],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+WSGI_APPLICATION = 'asites.wsgi.application'
+LOGIN_REDIRECT_URL = '/'
+########## END APPLICATION CONFIGURATION
+
+
+########## PASSWORD CONFIGURATION
+# https://docs.djangoproject.com/en/1.10/ref/settings/#auth-password-validators
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+########## END PASSWORD CONFIGURATION
+
+
+########## INTERNATIONALIZATION
+# https://docs.djangoproject.com/en/1.10/topics/i18n/
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'America/Vancouver'
+USE_I18N = True
+USE_L10N = True
+USE_TZ = True
+########## END INTERNATIONALIZATION
+
+
+########## STATIC FILES CONFIGURATION (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.10/howto/static-files/
+STATIC_URL = '/static/'
+########## END STATIC FILES CONFIGURATION
+
+
+########## REDMINE CONFIGURATION
+REDMINE_URL = env('REDMINE_URL')
+REDMINE_VER = env('REDMINE_VER')
+REDMINE_KEY = env('REDMINE_KEY')
+########## END REDMINE CONFIGURATION

--- a/asites/settings/local.py
+++ b/asites/settings/local.py
@@ -1,0 +1,16 @@
+"""
+Development environment settings and globals.
+Environment vars are defined in a .env file stored in the settings directory.
+"""
+
+from asites.settings.base import *
+
+########## DATABASE CONFIGURATION
+# https://docs.djangoproject.com/en/1.10/ref/settings/#databases
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(DJANGO_ROOT, 'db.sqlite3'),
+    }
+}
+########## END DATABASE CONFIGURATION

--- a/asites/settings/production.py
+++ b/asites/settings/production.py
@@ -55,14 +55,14 @@ DBBACKUP_STORAGE_OPTIONS = {
 ########## DATABASE CONFIGURATION
 # https://docs.djangoproject.com/en/1.10/ref/settings/#databases
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'projectmatica',
+	'default': {
+		'ENGINE': 'django.db.backends.postgresql_psycopg2',
+		'NAME': 'projectmatica',
 		'USER': env('DB_USER'),
 		'PASSWORD': env('DB_PASSWORD'),
 		'HOST': env('DB_HOST'),
 		'PORT': ''
-    }
+	}
 }
 ########## END DATABASE CONFIGURATION
 

--- a/asites/settings/production.py
+++ b/asites/settings/production.py
@@ -45,9 +45,9 @@ INSTALLED_APPS = [
 ########## BACKUP CONFIGURATION
 DBBACKUP_STORAGE = env('DBBACKUP_STORAGE')
 DBBACKUP_STORAGE_OPTIONS = {
-    'access_key': env('DB_ACCESS_KEY'),
-    'secret_key': env('DB_SECRET_KEY'),
-    'bucket_name': env('DB_BUCKET_NAME')
+    'access_key': env('DBBACKUP_ACCESS_KEY'),
+    'secret_key': env('DBBACKUP_SECRET_KEY'),
+    'bucket_name': env('DBBACKUP_BUCKET_NAME')
 }
 ########## END BACKUP CONFIGURATION
 
@@ -58,10 +58,10 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'projectmatica',
-	'USER': env('DB_USER'),
-	'PASSWORD': env('DB_PASSWORD'),
-	'HOST': env('DB_HOST'),
-	'PORT': '',
+		'USER': env('DB_USER'),
+		'PASSWORD': env('DB_PASSWORD'),
+		'HOST': env('DB_HOST'),
+		'PORT': ''
     }
 }
 ########## END DATABASE CONFIGURATION

--- a/asites/settings/production.py
+++ b/asites/settings/production.py
@@ -1,0 +1,73 @@
+"""
+Production environment settings and globals.
+Environment vars are defined in a .env file stored in the settings directory.
+"""
+
+from asites.settings.base import *
+
+########## SECURITY CONFIGURATION
+#SESSION_COOKIE_SECURE = True
+#CSRF_COOKIE_SECURE = True
+########## END SECURITY CONFIGURATION
+
+########## SITE CONFIGURATION
+ALLOWED_HOSTS = [env('ALLOWED_HOSTS')]
+########## END SITE CONFIGURATION
+
+
+########## EMAIL CONFIGURATION
+ADMINS = [(env('ADMIN_NAME'), env('ADMIN_EMAIL'))]
+
+EMAIL_HOST = env('EMAIL_HOST')
+EMAIL_HOST_USER = ''
+EMAIL_HOST_PASSWORD = ''
+
+MAILER_LIST = [env('MAILER_LIST')]
+DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL')
+########## END EMAIL CONFIGURATION
+
+
+########## APPLICATION CONFIGURATION
+INSTALLED_APPS = [
+    'pm.apps.PmConfig',
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'dbbackup',
+#    'csvimport.app.CSVImportConf',
+]
+########## END APPLICATION CONFIGURATION
+
+
+########## BACKUP CONFIGURATION
+DBBACKUP_STORAGE = env('DBBACKUP_STORAGE')
+DBBACKUP_STORAGE_OPTIONS = {
+    'access_key': env('DB_ACCESS_KEY'),
+    'secret_key': env('DB_SECRET_KEY'),
+    'bucket_name': env('DB_BUCKET_NAME')
+}
+########## END BACKUP CONFIGURATION
+
+
+########## DATABASE CONFIGURATION
+# https://docs.djangoproject.com/en/1.10/ref/settings/#databases
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'projectmatica',
+	'USER': env('DB_USER'),
+	'PASSWORD': env('DB_PASSWORD'),
+	'HOST': env('DB_HOST'),
+	'PORT': '',
+    }
+}
+########## END DATABASE CONFIGURATION
+
+
+########## STATIC FILES CONFIGURATION
+# STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
+STATIC_ROOT = os.path.join(DJANGO_ROOT, 'static/')
+########## END STATIC FILES CONFIGURATION

--- a/asites/wsgi.py
+++ b/asites/wsgi.py
@@ -8,9 +8,13 @@ https://docs.djangoproject.com/en/1.10/howto/deployment/wsgi/
 """
 
 import os
+from os.path import abspath, dirname
+from sys import path
+
+SITE_ROOT = dirname(dirname(abspath(__file__)))
+path.append(SITE_ROOT)
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "asites.settings.local")
 
 from django.core.wsgi import get_wsgi_application
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "asites.settings")
-
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "asites.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "asites.settings.local")
     try:
         from django.core.management import execute_from_command_line
     except ImportError:


### PR DESCRIPTION
Addresses #61.

Replaced settings.py with a settings folder containing base.py, local.py, and production.py, which are all now tracked in version control. Secrets are stored separately in a .env file (not tracked in version control) -- requires the django-environ module ([link to docs](http://django-environ.readthedocs.io/en/latest/index.html#)).

.gitignore could still use some cleaning up.

This approach can definitely be improved since it requires manually editing wsgi.py and manage.py after deployment to point to production.py (instead of local.py). I think a better approach would be to configure the server to point to the production settings, to avoid the potential need for manual code changes after each re-deployment.

This branch has been tested successfully in my local environment and on a test VM. It hasn't been deployed to the production VM yet.